### PR TITLE
Skip error on double update

### DIFF
--- a/ota.py
+++ b/ota.py
@@ -94,7 +94,10 @@ class OTAUpdater:
         print('Updating device...', end='')
 
         # Overwrite the old code.
-        os.rename('latest_code.py', self.filename)  
+        try:
+            os.rename('latest_code.py', self.filename)  
+        except OSError:
+            pass
 
         # Restart the device to run the new code.
         print("Restarting device... (don't worry about an error message after this")


### PR DESCRIPTION
inside download_and_install_update_if_available you call update_no_reset and then update_and_reset. both are renaming "latest_code.py" so in update_and_reset "latest_code.py" doesnt exsist this update bypasses the error